### PR TITLE
Typo fix on digitalOptInConfirmation

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/digitalcontact/digitalOptInConfirmation.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/digitalcontact/digitalOptInConfirmation.scala.html
@@ -31,7 +31,7 @@
     <p style="margin: 0 0 30px; font-size: 19px;">You can get a variety of tax letters online, such as if you owe tax or are due a refund (P800, PA302) or if you have a Self Assessment notice to file (an SA316 notice).</p>
 
 
-    <h2 style="margin: 0 0 30px; font-size: 19px;">Our promisess</h2>
+    <h2 style="margin: 0 0 30px; font-size: 19px;">Our promises</h2>
     <p style="margin: 0 0 30px; font-size: 19px;">If an email notification does not reach you and is returned to us, we’ll send the letter by post. This means you will never miss a tax letter.</p>
     <p style="margin: 0 0 30px; font-size: 19px;">We will never send private or sensitive information by email.</p>
     <p style="margin: 0 0 30px; font-size: 19px;">You can change the email address you use to get tax letters, and you can also choose to go back to getting all tax letters by post. Just go to ‘Check your settings’.</p>


### PR DESCRIPTION
Hi folks,
Fellow gov.uk dev. Spotted this typo in an email last night and thought I'd help out.

![image](https://github.com/furnivall/hmrc-email-renderer/assets/18507008/f952b82c-4936-49a8-bf0c-1dac4a492a29)

Hope it helps.